### PR TITLE
fix(Ingress): fix changes port object structure

### DIFF
--- a/premiers-pas/04-ingress.yaml
+++ b/premiers-pas/04-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: premiers-pas-hello-world
@@ -8,4 +8,5 @@ spec:
   defaultBackend:
     service:
       name: premiers-pas-hello-world
-      port: 80
+      port:
+        number: 80


### PR DESCRIPTION
Changes in defaultBackend service port object structure https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#servicebackendport-v1-networking-k8s-io